### PR TITLE
buildのワークフローをリリースの時には走らないようにする

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: Go Build
 
 on:
-  push:
+  pull_request:
     branches: [ main ]
 
 jobs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,6 @@
 name: Go Build
 
 on:
-  pull_request:
-    branches: [ main ]
   push:
     branches: [ main ]
 


### PR DESCRIPTION
release用のワークフロー内でビルドするようにしたので、
build.yamlはリリース時には走らないようにする