### PR TITLE
会話ログを保存するデフォルトのパスを指定できるようにする

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,7 +16,9 @@ type Prompt struct {
 }
 
 type Config struct {
-	Prompts map[string]Prompt `yaml:"prompts"`
+	LogDir       string            `yaml:"logDir"`
+	AutoSaveLogs bool              `yaml:"autoSaveLogs"`
+	Prompts      map[string]Prompt `yaml:"prompts"`
 }
 
 // LoadConfig は指定されたファイルパスから設定を読み込みます

--- a/utils.go
+++ b/utils.go
@@ -174,3 +174,24 @@ func DisplayConversationHistory(history []openai.ChatCompletionMessage) {
 		fmt.Printf("### %s\n\n%s\n\n", role, message.Content)
 	}
 }
+
+// GetLogDirectory は設定ファイルや環境変数に基づいてログの保存ディレクトリを取得します
+func GetLogDirectory(config Config) string {
+	if config.LogDir != "" {
+		return config.LogDir
+	}
+	// 環境変数XDG_DATA_HOMEを確認
+	if dataHome := os.Getenv("XDG_DATA_HOME"); dataHome != "" {
+		return filepath.Join(dataHome, "gpt-cli", "logs")
+	}
+	// デフォルトのログパスを使用
+	return filepath.Join(os.Getenv("HOME"), ".local", "share", "gpt-cli", "logs")
+}
+
+// EnsureDirectory は指定されたディレクトリパスが存在するか確認し、存在しない場合は作成します
+func EnsureDirectory(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return os.MkdirAll(path, 0700)
+	}
+	return nil
+}


### PR DESCRIPTION
config.yamlに設定を追加するとログの保存するパスを指定できる。
更に設定を追加すると自動で会話ログを保存する(デフォルトはオフ)