### PR TITLE
max-tokenを必須ではないようにする

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,7 +19,7 @@ type Prompt struct {
 	Model       string   `yaml:"model"`
 	System      string   `yaml:"system"`
 	User        string   `yaml:"user"`
-	MaxTokens   int      `yaml:"maxTokens"`
+	MaxTokens   *int     `yaml:"maxTokens"`
 	Attachments []string `yaml:"attachments"`
 	Tools       []string `yaml:"tools"`
 }

--- a/config_test.go
+++ b/config_test.go
@@ -35,7 +35,7 @@ prompts:
 		if prompt.User != "user message" {
 			t.Errorf("LoadConfig() は user を正しく読み取れませんでした")
 		}
-		if prompt.MaxTokens != 150 {
+		if prompt.MaxTokens == nil || *prompt.MaxTokens != 150 {
 			t.Errorf("LoadConfig() は maxTokens を正しく読み取れませんでした")
 		}
 		if len(prompt.Attachments) != 0 {

--- a/openai_client.go
+++ b/openai_client.go
@@ -34,14 +34,14 @@ func NewOpenAIClient(timeout int) (*openai.Client, error) {
 }
 
 // ExecuteChatCompletion はOpenAI APIにリクエストを送り、アシスタントの応答を取得します
-func ExecuteChatCompletion(client *openai.Client, model string, max_tokens int, conversationHistory []openai.ChatCompletionMessage) (openai.ChatCompletionMessage, error) {
+func ExecuteChatCompletion(client *openai.Client, model string, maxTokens *int, conversationHistory []openai.ChatCompletionMessage) (openai.ChatCompletionMessage, error) {
 	ctx := context.Background()
 
-	// MaxTokensをポインタ型に変更
-	var maxTokensPtr *int
-	if max_tokens > 0 {
-		maxTokensPtr = &max_tokens
-	}
+	// // MaxTokensをポインタ型に変更
+	// var maxTokensPtr *int
+	// if max_tokens > 0 {
+	// 	maxTokensPtr = &max_tokens
+	// }
 
 	// ChatCompletionRequest の作成
 	chatRequest := openai.ChatCompletionRequest{
@@ -50,8 +50,11 @@ func ExecuteChatCompletion(client *openai.Client, model string, max_tokens int, 
 	}
 
 	// MaxTokensが存在する場合に設定
-	if maxTokensPtr != nil {
-		chatRequest.MaxTokens = *maxTokensPtr
+	// if maxTokensPtr != nil {
+	// 	chatRequest.MaxTokens = *maxTokensPtr
+	// }
+	if maxTokens != nil {
+		chatRequest.MaxTokens = *maxTokens
 	}
 
 	resp, err := client.CreateChatCompletion(ctx, chatRequest)

--- a/options.go
+++ b/options.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -50,7 +51,7 @@ type Options struct {
 	FilePath             string
 	ToolConfigPath       string
 	Temperature          float64
-	MaxTokens            int
+	MaxTokens            *int
 	Metadata             map[string]interface{}
 	Attachments          []string
 	Tools                []string
@@ -94,7 +95,18 @@ func ParseCommandLineArgs() (Options, error) {
 	flag.Float64Var(&options.Temperature, "temperature", 0.7, "モデルの温度パラメータを指定")
 	flag.BoolVar(&options.CreateAssistant, "create-assistant", false, "新しいアシスタントを作成する")
 	flag.StringVar(&options.Message, "message", "", "アシスタントに送信するメッセージを指定")
-	flag.IntVar(&options.MaxTokens, "max-tokens", 16384, "Max tokens to generate in the completion")
+	// flag.IntVar(&options.MaxTokens, "max-tokens", 16384, "Max tokens to generate in the completion")
+
+	// MaxTokensのフラグを設定
+	options.MaxTokens = nil
+	flag.Func("max-tokens", "Max tokens to generate in the completion", func(s string) error {
+		value, err := strconv.Atoi(s)
+		if err != nil {
+			return err
+		}
+		options.MaxTokens = &value
+		return nil
+	})
 
 	flag.Parse()
 
@@ -116,10 +128,10 @@ func ParseCommandLineArgs() (Options, error) {
 		}
 	}
 
-	// コマンドライン引数から取得した max-tokens 値を Options 構造体に設定
-	if options.MaxTokens <= 0 {
-		options.MaxTokens = 200 // デフォルト値などを適切に設定
-	}
+	// // コマンドライン引数から取得した max-tokens 値を Options 構造体に設定
+	// if options.MaxTokens <= 0 {
+	// 	options.MaxTokens = 200 // デフォルト値などを適切に設定
+	// }
 
 	return options, nil
 }
@@ -192,7 +204,7 @@ func (o Options) String() string {
 	sb.WriteString(fmt.Sprintf("  Debug: %t\n", o.Debug))
 	sb.WriteString(fmt.Sprintf("  AssistantID: %s\n", o.AssistantID))
 	sb.WriteString(fmt.Sprintf("  Temperature: %f\n", o.Temperature))
-	sb.WriteString(fmt.Sprintf("  MaxTokens: %d\n", o.MaxTokens))
+	// sb.WriteString(fmt.Sprintf("  MaxTokens: %d\n", o.MaxTokens))
 	sb.WriteString(fmt.Sprintf("  ImageList: %s\n", o.ImageList))
 	sb.WriteString(fmt.Sprintf("	ConfigPath: %s\n", o.ConfigPath))
 	sb.WriteString(fmt.Sprintf("	ShowVersion: %t\n", o.ShowVersion))
@@ -222,6 +234,11 @@ func (o Options) String() string {
 	sb.WriteString(fmt.Sprintf("	Attachments: %s\n", o.Attachments))
 	sb.WriteString(fmt.Sprintf("	Tools: %s\n", strings.Join(o.Tools, ", ")))
 	sb.WriteString(fmt.Sprintf("	Args: %s\n", strings.Join(o.Args, ", ")))
+	if o.MaxTokens != nil {
+		sb.WriteString(fmt.Sprintf("  MaxTokens: %d\n", *o.MaxTokens))
+	} else {
+		sb.WriteString("  MaxTokens: <nil>\n")
+	}
 
 	return sb.String()
 }

--- a/prompt_config.go
+++ b/prompt_config.go
@@ -17,6 +17,9 @@ func GetPromptConfig(config Config, options Options) (Prompt, error) {
 	}
 
 	// コマンドライン引数からの上書き
+	if options.MaxTokens != nil {
+		promptConfig.MaxTokens = options.MaxTokens
+	}
 	if options.SystemMessage != "" {
 		promptConfig.System = options.SystemMessage
 	}
@@ -72,7 +75,6 @@ func GetDefaultPromptConfig() Prompt {
 		Model:       "gpt-3.5-turbo",
 		System:      "あなたはユーザーを助けるアシスタントです。",
 		User:        "ユーザーからのメッセージがまだありません。",
-		MaxTokens:   150,
 		Attachments: []string{},
 		Tools:       []string{},
 	}


### PR DESCRIPTION
o1-previewでは MaxTokens は使えなくなった。
変わりにMaxCompletionTokensを使うようになったが、ひとまずMaxTokensを必須としている処理をオフにする