### PR TITLE
チャット操作なしでファイル操作だけしたいケースに対応

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,6 +128,15 @@ func Run() error {
 		return handleVectorStoreAction(client, options)
 	}
 
+	if options.DeleteFileName != "" {
+		return handleDeleteFile(client, options)
+	}
+
 	// OpenAI API へのリクエスト
-	return handleChatCompletion(client, promptConfig, conversationHistory, options)
+	if options.UserMessage != "" {
+	  return handleChatCompletion(client, promptConfig, conversationHistory, options)
+	}
+	
+	// どの条件にも一致しない場合のデフォルトの戻り値
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -134,9 +134,9 @@ func Run() error {
 
 	// OpenAI API へのリクエスト
 	if options.UserMessage != "" {
-	  return handleChatCompletion(client, promptConfig, conversationHistory, options)
+		return handleChatCompletion(client, promptConfig, conversationHistory, options)
 	}
-	
+
 	// どの条件にも一致しない場合のデフォルトの戻り値
 	return nil
 }


### PR DESCRIPTION
以前はチャット操作をメインで使っていたが、ファイル操作だけしたいケースも出てきた。
最後に必ずhandleChatCompletion()が呼ばれる形だと都合が悪いので、ユーザーメッセージが付いている時だけhandleChatCompletion()を呼ぶようにする